### PR TITLE
feat(script): turn in up to 10

### DIFF
--- a/ExchangeNpc.lua
+++ b/ExchangeNpc.lua
@@ -140,7 +140,7 @@ local function eI_onGossipSelect(event, player, object, sender, intid, code, men
                 player:RemoveItem(Config.TurnInItemEntry[exchangeId], Config.TurnInItemAmount[exchangeId])
                 SendMail(Config.mailSubject, Config.mailMessage, playerGuid, 0, 61, 5, 0, 0, Config.GainItemEntry[exchangeId], Config.GainItemAmount[exchangeId])
                 player:SendBroadcastMessage(Config.ExchangeSuccessfulMessage)
-            elseif n == amount
+            elseif n == amount then
                 player:SendBroadcastMessage(Config.NotEnoughItemsMessage)
             end
         end

--- a/ExchangeNpc.lua
+++ b/ExchangeNpc.lua
@@ -124,16 +124,25 @@ local function eI_onGossipSelect(event, player, object, sender, intid, code, men
         local exchangeId = intid + 1
         local newintid = intid + 1000
         player:GossipMenuAddItem(OPTION_ICON_CHAT, 'Yes! '..Config.GossipOptionText[exchangeId], Config.NpcEntry, newintid)
+        player:GossipMenuAddItem(OPTION_ICON_CHAT, 'Yes! '..Config.GossipOptionText[exchangeId]..' (Turn in up to 10 at once)', Config.NpcEntry, newintid + 1000)
         player:GossipSendMenu(Config.GossipConfirmationText, object, 0)
     else
         local playerGuid = tonumber(tostring(player:GetGUID()))
         local exchangeId = intid - 999
-        if player:HasItem(Config.TurnInItemEntry[exchangeId], Config.TurnInItemAmount[exchangeId], false) then
-            player:RemoveItem(Config.TurnInItemEntry[exchangeId], Config.TurnInItemAmount[exchangeId])
-            SendMail(Config.mailSubject, Config.mailMessage, playerGuid, 0, 61, 5, 0, 0, Config.GainItemEntry[exchangeId], Config.GainItemAmount[exchangeId])
-            player:SendBroadcastMessage(Config.ExchangeSuccessfulMessage)
-        else
-            player:SendBroadcastMessage(Config.NotEnoughItemsMessage)
+        local amount = 1
+        if exchangeId > 1000 then
+            exchangeId = exchangeId - 1000
+            amount = 10
+        end
+        local n
+        for n = 1,amount do
+            if player:HasItem(Config.TurnInItemEntry[exchangeId], Config.TurnInItemAmount[exchangeId], false) then
+                player:RemoveItem(Config.TurnInItemEntry[exchangeId], Config.TurnInItemAmount[exchangeId])
+                SendMail(Config.mailSubject, Config.mailMessage, playerGuid, 0, 61, 5, 0, 0, Config.GainItemEntry[exchangeId], Config.GainItemAmount[exchangeId])
+                player:SendBroadcastMessage(Config.ExchangeSuccessfulMessage)
+            elseif n == amount
+                player:SendBroadcastMessage(Config.NotEnoughItemsMessage)
+            end
         end
         player:GossipComplete()
     end


### PR DESCRIPTION
Players should now be able to turn in 1 or up to 10 sets at once.
Choosing the "Up to 10" option, will result in 10 checks if 1 item is available and a mail sent for each item. 
If 10 exchanges are succesful, 10 mails are sent. If less than 10 exchanges are succesful, a single error message will fire. But the player will still receive the items from succesful attempts via mail.